### PR TITLE
Enable strong mode and fix a warning.

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -1,0 +1,2 @@
+analyzer:
+  strong-mode: true

--- a/lib/src/zoned_value.dart
+++ b/lib/src/zoned_value.dart
@@ -32,6 +32,6 @@ class ZonedValue<T> {
   T get value {
     // TODO: Allow null values when http://dartbug.com/21247 is fixed.
     var v = Zone.current[_valueKey];
-    return v != null ? v : _rootValue;
+    return v != null ? v as T : _rootValue;
   }
 }


### PR DESCRIPTION
For context, we're working on making the core Dart packages and their transitive dependencies—which include this—strong-mode clean.
