### PR TITLE
Bump to version 1.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: clock
-version: 0.1.2
+version: 1.0.0
 author: Sean Eagan <seaneagan1@gmail.com>
 description: Provides testable replacements for the system clock APIs (`new DateTime.now()` and `new Stopwatch()`).
 homepage: https://github.com/seaneagan/clock


### PR DESCRIPTION
The api has been stable for a while now. Convey this by marking as
version 1.0.0